### PR TITLE
Add twig support for translation plugin

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -49,8 +49,7 @@ class Plugin extends PluginBase {
         $pluginManager = \System\Classes\PluginManager::instance()->findByIdentifier('Rainlab.Translate');
 
         if ($pluginManager && !$pluginManager->disabled) {
-           $trans = \RainLab\Translate\Classes\Translator::class;
-           $settings->translateContext($trans::instance()->getLocale());
+           $settings->translateContext(\RainLab\Translate\Classes\Translator::instance()->getLocale());
         }
 
         return [

--- a/Plugin.php
+++ b/Plugin.php
@@ -44,15 +44,20 @@ class Plugin extends PluginBase {
     }
 
     public function registerMarkupTags() {
+        $settings = CookiesSettings::instance();
+        if (class_exists($trans = \RainLab\Translate\Classes\Translator::class)) {
+            $settings->translateContext($trans::instance()->getLocale());
+        }
+
         return [
             'filters' => [],
             'functions' => [
-                'cookiesSettingsGet' => function ($value, $default = NULL) {
-                    
-                    if(empty(CookiesSettings::get($value))) {
+                'cookiesSettingsGet' => function ($value, $default = NULL) use ($settings){
+
+                    if(empty($settings->$value)) {
                         return $default;
                     } else {
-                        return CookiesSettings::get($value);
+                        return $settings->$value;
                     }
                 }
             ]

--- a/Plugin.php
+++ b/Plugin.php
@@ -49,7 +49,7 @@ class Plugin extends PluginBase {
         $pluginManager = \System\Classes\PluginManager::instance()->findByIdentifier('Rainlab.Translate');
 
         if ($pluginManager && !$pluginManager->disabled) {
-           $settings->translateContext(\RainLab\Translate\Classes\Translator::instance()->getLocale());
+            $settings->translateContext(\RainLab\Translate\Classes\Translator::instance()->getLocale());
         }
 
         return [

--- a/Plugin.php
+++ b/Plugin.php
@@ -44,9 +44,13 @@ class Plugin extends PluginBase {
     }
 
     public function registerMarkupTags() {
+
         $settings = CookiesSettings::instance();
-        if (class_exists($trans = \RainLab\Translate\Classes\Translator::class)) {
-            $settings->translateContext($trans::instance()->getLocale());
+        $pluginManager = \System\Classes\PluginManager::instance()->findByIdentifier('Rainlab.Translate');
+
+        if ($pluginManager && !$pluginManager->disabled) {
+           $trans = \RainLab\Translate\Classes\Translator::class;
+           $settings->translateContext($trans::instance()->getLocale());
         }
 
         return [


### PR DESCRIPTION
Plugin not work with Multi-Lang Pages (**https://octobercms.com/plugin/rainlab-translate Plugin**).
I edited "registerMarkupTags" function. If "Translate Plugin" exist, then load and return translated data.